### PR TITLE
updates snapshot version to follow release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-spring-boot-starters</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Microsoft Azure Spring Boot Starters</name>


### PR DESCRIPTION
updates snapshot version to follow maven release version, we are not following standard version naming . It should be updated automatically. 

If you are Ok I can provide a PR to use maven release plugin which seamlessly allows to update versions and release project.