### PR TITLE
removes unnecessary dependency

### DIFF
--- a/spring-data-azure-documentdb/pom.xml
+++ b/spring-data-azure-documentdb/pom.xml
@@ -41,10 +41,6 @@
         <url>https://github.com/Microsoft/azure-spring-boot-starters/tree/master</url>
     </scm>
 
-    <properties>
-        <mockito.version>1.10.19</mockito.version>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -103,11 +99,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Mockito core is part of spring-boot-starter-test transitive dependency hence removing this dependency