### PR TITLE
Polish configuration to avoid warnings

### DIFF
--- a/azure-documentdb-spring-boot-autoconfigure-sample/pom.xml
+++ b/azure-documentdb-spring-boot-autoconfigure-sample/pom.xml
@@ -55,6 +55,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/azure-documentdb-spring-boot-starter-sample/pom.xml
+++ b/azure-documentdb-spring-boot-starter-sample/pom.xml
@@ -59,6 +59,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/azure-storage-spring-boot-starter-sample/pom.xml
+++ b/azure-storage-spring-boot-starter-sample/pom.xml
@@ -56,6 +56,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     </scm>
 
     <properties>
+    	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <azure.doucmentdb.starter.version>0.1.3</azure.doucmentdb.starter.version>
         <azure.doucmentdb.autoconfigure.version>0.1.3</azure.doucmentdb.autoconfigure.version>
         <spring.data.documentdb.version>0.1.3</spring.data.documentdb.version>
@@ -50,6 +51,7 @@
         <azure.documentdb.version>1.11.0</azure.documentdb.version>
         <azure.servicebus.version>1.0.0-PREVIEW-3</azure.servicebus.version>
         <azure.storage.version>5.3.1</azure.storage.version>
+        <spring.boot.version>1.5.4.RELEASE</spring.boot.version>
     </properties>
 
     <dependencyManagement>
@@ -58,7 +60,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.5.4.RELEASE</version>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-data-azure-documentdb-sample/pom.xml
+++ b/spring-data-azure-documentdb-sample/pom.xml
@@ -55,6 +55,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This pull request does the following

- Moves declaration of spring boot version to property so that users can play with it and is easier to configure 
- creates same encoding across platforms for source code
- Fixes warning that arise while doing maven build

Below is sample screenshot.
![image](https://user-images.githubusercontent.com/24761580/28156890-1e343582-67d2-11e7-8173-9fe7c60bc9b8.png)
