### PR TITLE
Fixes submodule build failure

### DIFF
--- a/azure-spring-boot-starter-parent/pom.xml
+++ b/azure-spring-boot-starter-parent/pom.xml
@@ -101,6 +101,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <configLocation>../config/checkstyle.xml</configLocation>
+                            <headerLocation>../config/java.header</headerLocation>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -14,7 +14,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
     </module>
 
     <module name="Header">
-        <property name="headerFile" value="config/java.header"/>
         <property name="fileExtensions" value="java"/>
     </module>
 


### PR DESCRIPTION
moving header from checkstyle to plugin allows users to run from subproject as well 
Fixes https://github.com/Microsoft/azure-spring-boot-starters/issues/46

@xscript @yungez @aovechki @ZhijunZhao 