### PR TITLE
defaulting to singleton Bean scope

### DIFF
--- a/mediaservices/azure-mediaservices-spring-boot-autoconfigure/src/main/java/com/microsoft/azure/autoconfigure/mediaservices/MediaServicesAutoConfiguration.java
+++ b/mediaservices/azure-mediaservices-spring-boot-autoconfigure/src/main/java/com/microsoft/azure/autoconfigure/mediaservices/MediaServicesAutoConfiguration.java
@@ -16,7 +16,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 
 import static com.microsoft.windowsazure.Configuration.*;
 import static java.util.Objects.isNull;
@@ -42,7 +41,6 @@ public class MediaServicesAutoConfiguration {
      * @throws ServiceException
      */
     @Bean
-    @Scope("prototype")
     public MediaContract mediaContract() throws ServiceException {
         LOG.debug("mediaContract called");
         return createMediaContract();


### PR DESCRIPTION
As only one client connection should be established using prototype is not correct , hence reverting to default singleton scope.
cc @xscript @yungez @aovechki @ZhijunZhao