### PR TITLE
Add missing documentdb metadata

### DIFF
--- a/documentdb/azure-documentdb-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/documentdb/azure-documentdb-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "azure.documentdb.repositories.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable DocumentDb repositories.",
+      "defaultValue": true
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds the missing `azure.documentdb.repositories.enabled` in
the metadata.