### PR TITLE
Implement exists based on findOne

### DIFF
--- a/documentdb/spring-data-azure-documentdb/src/main/java/com/microsoft/azure/spring/data/documentdb/repository/support/SimpleDocumentDbRepository.java
+++ b/documentdb/spring-data-azure-documentdb/src/main/java/com/microsoft/azure/spring/data/documentdb/repository/support/SimpleDocumentDbRepository.java
@@ -102,7 +102,7 @@ public class SimpleDocumentDbRepository<T, ID extends Serializable> implements D
 
     @Override
     public boolean exists(ID primaryKey) {
-        throw new UnsupportedOperationException("exists not supported yet.");
+        return findOne(primaryKey) != null;
     }
 
 }


### PR DESCRIPTION
Trivial implementation of `exists` based on `findOne` returning not `null`